### PR TITLE
constructor handling added, fallback handling improved

### DIFF
--- a/lib/components/document.js
+++ b/lib/components/document.js
@@ -858,7 +858,6 @@ function compareItemDefinitionsByName(itemDefinition1, itemDefinition2) {
 /**
  * Display name for fallback function.
  */
-var FUNCTION_NAME_CONSTRUCTOR = 'constructor';
 var FUNCTION_NAME_FALLBACK = 'fallback';
 
 /**
@@ -867,12 +866,7 @@ var FUNCTION_NAME_FALLBACK = 'fallback';
 function getItemName(itemDefinition) {
   var nodeType = (0, _safeGet2.default)(itemDefinition, 'item', 'nodeType');
   var name = (0, _safeGet2.default)(itemDefinition, 'item', 'name');
-  
   if (nodeType === _astNodeType2.default.FUNCTION_DEFINITION && name === '') {
-    var parameters = (0, _safeGet2.default)(itemDefinition, 'item', 'parameters');
-    var returnParameters = (0, _safeGet2.default)(itemDefinition, 'item', 'returnParameters');
-    if(parameters.parameters.length == 0 && returnParameters.parameters.length == 0)
-      return FUNCTION_NAME_FALLBACK;
     return FUNCTION_NAME_CONSTRUCTOR;
   }
   return name;

--- a/lib/components/document.js
+++ b/lib/components/document.js
@@ -858,6 +858,7 @@ function compareItemDefinitionsByName(itemDefinition1, itemDefinition2) {
 /**
  * Display name for fallback function.
  */
+var FUNCTION_NAME_CONSTRUCTOR = 'constructor';
 var FUNCTION_NAME_FALLBACK = 'fallback';
 
 /**
@@ -866,8 +867,13 @@ var FUNCTION_NAME_FALLBACK = 'fallback';
 function getItemName(itemDefinition) {
   var nodeType = (0, _safeGet2.default)(itemDefinition, 'item', 'nodeType');
   var name = (0, _safeGet2.default)(itemDefinition, 'item', 'name');
+  
   if (nodeType === _astNodeType2.default.FUNCTION_DEFINITION && name === '') {
-    return FUNCTION_NAME_FALLBACK;
+    var parameters = (0, _safeGet2.default)(itemDefinition, 'item', 'parameters');
+    var returnParameters = (0, _safeGet2.default)(itemDefinition, 'item', 'returnParameters');
+    if(parameters.parameters.length == 0 && returnParameters.parameters.length == 0)
+      return FUNCTION_NAME_FALLBACK;
+    return FUNCTION_NAME_CONSTRUCTOR;
   }
   return name;
 }

--- a/lib/components/document.js
+++ b/lib/components/document.js
@@ -867,7 +867,7 @@ function getItemName(itemDefinition) {
   var nodeType = (0, _safeGet2.default)(itemDefinition, 'item', 'nodeType');
   var name = (0, _safeGet2.default)(itemDefinition, 'item', 'name');
   if (nodeType === _astNodeType2.default.FUNCTION_DEFINITION && name === '') {
-    return FUNCTION_NAME_CONSTRUCTOR;
+    return FUNCTION_NAME_FALLBACK;
   }
   return name;
 }

--- a/src/components/document.js
+++ b/src/components/document.js
@@ -638,9 +638,10 @@ function compareItemDefinitionsByName (itemDefinition1, itemDefinition2) {
 }
 
 /**
- * Display name for fallback function.
+ * Display name for fallback & constructor function.
  */
 const FUNCTION_NAME_FALLBACK = 'fallback'
+var FUNCTION_NAME_CONSTRUCTOR = 'constructor';
 
 /**
  * Get an item's name.
@@ -649,6 +650,9 @@ function getItemName (itemDefinition) {
   const nodeType = get(itemDefinition, 'item', 'nodeType')
   const name = get(itemDefinition, 'item', 'name')
   if (nodeType === AstNodeType.FUNCTION_DEFINITION && name === '') {
+    const isConstructor = get(itemDefinition, 'item', 'isConstructor');
+    if(isConstructor)
+      return FUNCTION_NAME_CONSTRUCTOR
     return FUNCTION_NAME_FALLBACK
   }
   return name

--- a/src/components/document.js
+++ b/src/components/document.js
@@ -641,7 +641,7 @@ function compareItemDefinitionsByName (itemDefinition1, itemDefinition2) {
  * Display name for fallback & constructor function.
  */
 const FUNCTION_NAME_FALLBACK = 'fallback'
-var FUNCTION_NAME_CONSTRUCTOR = 'constructor';
+const FUNCTION_NAME_CONSTRUCTOR = 'constructor';
 
 /**
  * Get an item's name.


### PR DESCRIPTION
Fixes #15 

As solidity version has been updated, we need to differentiate between `constructor` and `fallback` , that is done in this.
![docgen2](https://user-images.githubusercontent.com/30843294/48549148-f5e6ad80-e8f4-11e8-8ce5-ed13d8a5788e.png)
