### PR TITLE
Fix a bug on contract source links

### DIFF
--- a/src/components/document.js
+++ b/src/components/document.js
@@ -10,6 +10,7 @@ import AstWalker from '../ast/ast-walker'
 import get from '../util/safe-get'
 import parseNatspec from '../util/parse-natspec'
 import React from 'react'
+import path from 'path'
 
 /**
  * Render the content of a Docusaurus document for a specific contract.
@@ -93,8 +94,10 @@ function BaseContracts (props) {
  */
 function ContractSource (props) {
   const { contractsPath, absolutePath, version, repoBaseUrl } = props
+  const basename = path.basename(repoBaseUrl);
+  const relativeContractsPath = contractsPath.slice(contractsPath.lastIndexOf(basename) + basename.length + 1);
   const relativePath = absolutePath.slice(contractsPath.length + 1)
-  const href = `${repoBaseUrl}/blob/v${version}/contracts/${relativePath}`
+  const href = `${repoBaseUrl.replace('git+', '')}/blob/v${version}/${relativeContractsPath}/${relativePath}`
   return (
     <div className='source'>
       Source:&nbsp;<a href={href} target='_blank'>{relativePath}</a>


### PR DESCRIPTION
Solidity contract source code links were broken for any project that does not have its `contracts` folder at its root. This is the case in ZeppelinOS, for example with `zos/packages/lib/contracts`.

Also, if the base url of the repository of the project contains a `git+` element, the resulting link does not work.

This PR removes the `git+` element from the link, if present, and uses the name of the repository to construct a valid relative path for the contracts folder.