### PR TITLE
Support the documentation of global variables

### DIFF
--- a/src/solc.ts
+++ b/src/solc.ts
@@ -31,6 +31,8 @@ export namespace ast {
     nodeType: 'VariableDeclaration';
     visibility: 'internal' | 'public' | 'private';
     name: string;
+    constant: boolean;
+    typeName: TypeName;
   }
 
   export interface FunctionDefinition {

--- a/src/solc.ts
+++ b/src/solc.ts
@@ -31,7 +31,6 @@ export namespace ast {
     nodeType: 'VariableDeclaration';
     visibility: 'internal' | 'public' | 'private';
     name: string;
-    documentation: string | null;
   }
 
   export interface FunctionDefinition {

--- a/src/solc.ts
+++ b/src/solc.ts
@@ -25,7 +25,14 @@ export namespace ast {
     linearizedBaseContracts: number[];
   }
 
-  export type ContractItem = FunctionDefinition | EventDefinition | ModifierDefinition;
+  export type ContractItem = VariableDeclaration | FunctionDefinition | EventDefinition | ModifierDefinition;
+
+  export interface VariableDeclaration {
+    nodeType: 'VariableDeclaration';
+    visibility: 'internal' | 'public' | 'private';
+    name: string;
+    documentation: string | null;
+  }
 
   export interface FunctionDefinition {
     nodeType: 'FunctionDefinition';

--- a/src/solc.ts
+++ b/src/solc.ts
@@ -166,4 +166,23 @@ export class SolcOutputBuilder implements Output {
     contract.astNode.nodes.push(astNode);
     return this;
   }
+
+  variable(variableName: string, typeString: string) {
+    const contract = this._currentContract;
+    if (contract === undefined) throw new Error('No contract defined');
+    const astNode: ast.VariableDeclaration = {
+      nodeType: 'VariableDeclaration',
+      visibility: 'public',
+      name: variableName,
+      constant: false,
+      typeName: {
+        nodeType: 'ElementaryTypeName',
+        typeDescriptions: {
+          typeString,
+        },
+      },
+    }
+    contract.astNode.nodes.push(astNode);
+    return this;
+  }
 }

--- a/src/solidity.test.ts
+++ b/src/solidity.test.ts
@@ -123,3 +123,34 @@ test('two inherited constructors', t => {
   t.is(foof.name, 'FooFlavor');
   t.is(foof.functions.length, 1);
 });
+
+test('a state variable', t => {
+  const solcOutput = new SolcOutputBuilder()
+    .file('Foo.sol')
+    .contract('Foo')
+      .variable('x', 'uint256');
+
+  const source = buildSource(solcOutput);
+  const foo = source.contracts[0];
+  t.is(foo.variables.length, 1);
+  const variable = foo.variables[0];
+  t.is(variable.name, 'x');
+  t.is(variable.type, 'uint256');
+});
+
+test('an inherited state variable', t => {
+  const solcOutput = new SolcOutputBuilder()
+    .file('Foo.sol')
+    .contract('Foo')
+      .variable('x', 'uint256')
+    .contract('Bar', 'Foo')
+      .variable('y', 'uint256');
+
+  const source = buildSource(solcOutput);
+  const foo = source.contracts[1];
+  t.is(foo.name, 'Bar');
+  t.is(foo.variables.length, 2);
+  const variable = foo.variables[1];
+  t.is(variable.name, 'x');
+  t.is(variable.type, 'uint256');
+});

--- a/src/solidity.ts
+++ b/src/solidity.ts
@@ -205,12 +205,24 @@ abstract class SolidityContractItem implements Linkable {
   }
 }
 
-class SolidityVariable extends SolidityContractItem {
+class SolidityVariable implements Linkable {
   constructor(
-    contract: SolidityContract,
-    protected readonly astNode: solc.ast.VariableDeclaration,
-  ) {
-    super(contract, astNode);
+    readonly contract: SolidityContract,
+    astNode: solc.ast.ContractItem,
+  ) { }
+
+  protected abstract astNode: solc.ast.ContractItem;
+
+  get name(): string {
+    return this.astNode.name;
+  }
+
+  get fullName(): string {
+    return `${this.contract.name}.${this.name}`
+  }
+
+  get anchor(): string {
+    return `${this.contract.name}-${slug(this.signature)}`
   }
 
   get type(): string {

--- a/src/solidity.ts
+++ b/src/solidity.ts
@@ -198,17 +198,17 @@ abstract class SolidityContractItem implements Linkable {
   }
 
   get fullName(): string {
-    return `${this.contract.name}.${this.name}`
+    return `${this.contract.name}.${this.name}`;
   }
 
   get anchor(): string {
-    return `${this.contract.name}-${slug(this.signature)}`
+    return `${this.contract.name}-${slug(this.signature)}`;
   }
 
   @memoize
   get args(): SolidityTypedVariable[] {
     return SolidityTypedVariableArray.fromParameterList(
-      this.astNode.parameters
+      this.astNode.parameters,
     );
   }
 

--- a/src/solidity.ts
+++ b/src/solidity.ts
@@ -249,6 +249,11 @@ class SolidityStateVariable implements Linkable {
   get signature(): string {
     return `${this.type} ${this.name}`;
   }
+
+  get natspec(): {} {
+    warnStateVariableNatspec();
+    return {}
+  }
 }
 
 class SolidityFunction extends SolidityContractItem {
@@ -469,3 +474,16 @@ function isEventDefinition(node: solc.ast.ContractItem): node is solc.ast.EventD
 function isModifierDefinition(node: solc.ast.ContractItem): node is solc.ast.ModifierDefinition {
   return node.nodeType === 'ModifierDefinition';
 }
+
+function oneTimeLogger(msg: string): () => void {
+  let warned = false;
+
+  return function () {
+    if (!warned) {
+      console.warn(msg);
+      warned = true;
+    }
+  };
+}
+
+const warnStateVariableNatspec = oneTimeLogger('Warning: NatSpec is currently not available for state variables.');

--- a/src/solidity.ts
+++ b/src/solidity.ts
@@ -214,7 +214,7 @@ class SolidityVariable extends SolidityContractItem {
   }
 
   get type(): string {
-    return this.astNode.typeName.name;
+    return this.astNode.typeName.typeDescriptions.typeString;
   }
 
   get signature(): string {

--- a/src/solidity.ts
+++ b/src/solidity.ts
@@ -222,10 +222,7 @@ class SolidityVariable extends SolidityContractItem {
   }
 
   get natspec(): NatSpec {
-    if (this.astNode.documentation) {
-      return parseNatSpec(this.astNode.documentation);
-    }
-    return {};
+    throw new Error("NatSpec currently does NOT apply to public state variables (see https://github.com/ethereum/solidity/issues/3418)");
   }
 }
 

--- a/src/solidity.ts
+++ b/src/solidity.ts
@@ -188,7 +188,6 @@ export class SolidityContract implements Linkable {
 abstract class SolidityContractItem implements Linkable {
   constructor(
     readonly contract: SolidityContract,
-    astNode: solc.ast.ContractItem,
   ) { }
 
   protected abstract astNode: solc.ast.ContractItem;
@@ -263,7 +262,7 @@ class SolidityFunction extends SolidityContractItem {
     contract: SolidityContract,
     protected readonly astNode: solc.ast.FunctionDefinition,
   ) {
-    super(contract, astNode);
+    super(contract);
   }
 
   get name(): string {
@@ -298,7 +297,7 @@ class SolidityEvent extends SolidityContractItem {
     contract: SolidityContract,
     protected readonly astNode: solc.ast.EventDefinition,
   ) {
-    super(contract, astNode);
+    super(contract);
   }
 }
 
@@ -307,7 +306,7 @@ class SolidityModifier extends SolidityContractItem {
     contract: SolidityContract,
     protected readonly astNode: solc.ast.ModifierDefinition,
   ) {
-    super(contract, astNode);
+    super(contract);
   }
 }
 

--- a/src/solidity.ts
+++ b/src/solidity.ts
@@ -90,7 +90,7 @@ export class SolidityContract implements Linkable {
   }
 
   get linkable(): Linkable[] {
-    return [this, ...this.functions, ...this.events];
+    return [this, ...this.functions, ...this.events, ...this.variables];
   }
 
   get inheritance(): SolidityContract[] {

--- a/src/solidity.ts
+++ b/src/solidity.ts
@@ -213,7 +213,7 @@ abstract class SolidityContractItem implements Linkable {
   }
 
   get signature(): string {
-    return `${this.name}(${this.args.map(a => a.typeName).join(',')})`;
+    return `${this.name}(${this.args.map(a => a.type).join(',')})`;
   }
 
   get natspec(): NatSpec {
@@ -313,19 +313,24 @@ class SolidityModifier extends SolidityContractItem {
 
 class SolidityTypedVariable {
   constructor(
-    readonly type: solc.ast.TypeName,
+    private readonly typeNode: solc.ast.TypeName,
     readonly name?: string,
   ) { }
 
+  get type(): string {
+    return this.typeNode.typeDescriptions.typeString;
+  }
+
+  // TODO: deprecate
   get typeName() {
-    return this.type.typeDescriptions.typeString;
+    return this.type;
   }
 
   toString(): string {
     if (this.name) {
-      return [this.typeName, this.name].join(' ');
+      return [this.type, this.name].join(' ');
     } else {
-      return this.typeName;
+      return this.type;
     }
   }
 }
@@ -356,7 +361,7 @@ class SolidityTypedVariableArray extends PrettyArray<SolidityTypedVariable> {
   }
 
   get types(): string[] {
-    return this.map(v => v.typeName);
+    return this.map(v => v.type);
   }
 
   get names(): string[] {

--- a/src/solidity.ts
+++ b/src/solidity.ts
@@ -222,7 +222,7 @@ class SolidityVariable extends SolidityContractItem {
   }
 
   get natspec(): NatSpec {
-    throw new Error("NatSpec currently does NOT apply to public state variables (see https://github.com/ethereum/solidity/issues/3418)");
+    throw new Error("NatSpec is currently not available for public state variables (see https://github.com/ethereum/solidity/issues/3418)");
   }
 }
 


### PR DESCRIPTION
Following [this feature-request](https://github.com/OpenZeppelin/solidity-docgen/issues/43), extend the `solidity-docgen` package to support the documentation of global variables, which are implicitly added by the compiler as getter functions in the contract.

This should allow users to get the natspec-documentation of their global variables added into the `solidity-docgen` output by declaring it appropriately in the input template (hbs) file.

For example:
```
{{#if ownVariables}}
# Variables:
{{#ownVariables}}
- [`{{type}} {{name}}`](#{{anchor}})
{{/ownVariables}}
{{/if}}

{{#ownVariables}}
# Variable `{{type}} {{name}}` {#{{anchor~}} }
{{#if natspec.devdoc}}{{natspec.devdoc}}{{else}}No description{{/if}}
{{/ownVariables}}
```
Note that this PR is incomplete, since the `devdoc` of a global variable is always `undefined`.

For this reason, I also had to override function `SolidityContractItem.natspec()` in class `SolidityVariable` with a slightly different implementation (since `this.astNode.documentation === undefined`).

Thanks