### PR TITLE
Allow users to configure compiler-settings

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,7 +46,7 @@ class Docgen extends Command {
       description: 'path to an alternative solc module',
     }),
 
-    'solc-settings': flags.string({
+    'solc-settings': flags.build({
       parse: s => JSON.parse(s),
       description: 'compiler settings for solc module',
     }),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,7 +47,14 @@ class Docgen extends Command {
     }),
 
     'solc-settings': flags.build({
-      parse: s => JSON.parse(s),
+      parse: s => {
+        const settings = JSON.parse(s) as unknown;
+        if (typeof settings !== 'object' || settings === null) {
+          throw new Error('--solc-settings must be an object');
+        }
+        return settings;
+      },
+    })({
       description: 'compiler settings for solc module',
     }),
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,6 +46,11 @@ class Docgen extends Command {
       description: 'path to an alternative solc module',
     }),
 
+    'solc-settings': flags.string({
+      parse: s => JSON.parse(s),
+      description: 'compiler settings for solc module',
+    }),
+
     'contract-pages': flags.boolean({
       default: false,
       description: 'enable one page per contract',

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -20,6 +20,7 @@ export async function compile(
   directory: string,
   ignore: string[] = [],
   solcModule: string = 'solc',
+  solcSettings: object = {optimizer: {enabled: true, runs: 200}},
 ): Promise<SolcOutput> {
   const solc = await SolcAdapter.require(solcModule);
 
@@ -35,7 +36,7 @@ export async function compile(
   const solcInput = {
     language: "Solidity",
     sources: sources,
-    settings: compilerSettings,
+    settings: {...compilerSettings, ...solcSettings},
   };
 
   const solcOutput = solc.compile(solcInput);

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -36,7 +36,7 @@ export async function compile(
   const solcInput = {
     language: "Solidity",
     sources: sources,
-    settings: {...compilerSettings, ...solcSettings},
+    settings: { ...solcSettings, outputSelection },
   };
 
   const solcOutput = solc.compile(solcInput);

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -6,13 +6,11 @@ import semver from 'semver';
 
 import { Output as SolcOutput } from './solc';
 
-const compilerSettings = {
-  outputSelection: {
-    '*': {
-      '': [
-        'ast',
-      ],
-    },
+const outputSelection = {
+  '*': {
+    '': [
+      'ast',
+    ],
   },
 };
 

--- a/src/docgen.ts
+++ b/src/docgen.ts
@@ -24,7 +24,7 @@ interface Templates {
 }
 
 export async function docgen(options: Options) {
-  const solcOutput = await compile(options.input, options.exclude, options['solc-module']);
+  const solcOutput = await compile(options.input, options.exclude, options['solc-module'], options['solc-settings']);
   const templates = await getTemplates(options.templates);
   const readmes = await getReadmes(options.input);
 

--- a/src/docgen.ts
+++ b/src/docgen.ts
@@ -15,6 +15,7 @@ interface Options {
   exclude?: string[];
   extension: string;
   'solc-module'?: string;
+  'solc-settings'?: object;
   'contract-pages': boolean;
 }
 


### PR DESCRIPTION
Add input parameter `solcSettings` to function `compile`.
The default value for this parameter is `{optimizer: {enabled: true, runs: 200}}`, identical to the Solidity Compiler's default configuration.

This feature is in fact very important, because certain compiler-settings may yield the difference between successful compilation and unsuccessful compilation.
Thus, without this feature, users might find themselves being able to compile their contracts but unable to execute `solidity-docgen`, as a result of the latter failing to compile the exact same contracts.
Hence this feature can also be considered as a bug fix.

You can see a living-example of the scenario above in [this contract](https://github.com/bancorprotocol/contracts/blob/0.5.0/solidity/contracts/BancorNetwork.sol) (note that it is currently on a branch and will be moved to master in the future, so use [this link](https://github.com/bancorprotocol/contracts/blob/master/solidity/contracts/BancorNetwork.sol) if the previous one is broken).
The compilation error `Stack too deep` is emitted only when optimization is disabled.

TODO: Add a description of the `solcSettings` configuration parameter in the README file.