### PR TITLE
Allow more advanced programming via the template file

### DIFF
--- a/src/handlebars.ts
+++ b/src/handlebars.ts
@@ -25,7 +25,7 @@ H.registerHelper({
         return [...arguments].every(Boolean);
     },
     or: function () {
-        return Array.prototype.slice.call(arguments, 0, -1).some(Boolean);
+        return [...arguments].some(Boolean);
     }
 });
 

--- a/src/handlebars.ts
+++ b/src/handlebars.ts
@@ -2,6 +2,32 @@ import handlebars from 'handlebars';
 
 const H = handlebars.create();
 H.registerHelper('slug', slug);
+H.registerHelper({
+    eq: function (v1, v2) {
+        return v1 === v2;
+    },
+    ne: function (v1, v2) {
+        return v1 !== v2;
+    },
+    lt: function (v1, v2) {
+        return v1 < v2;
+    },
+    gt: function (v1, v2) {
+        return v1 > v2;
+    },
+    lte: function (v1, v2) {
+        return v1 <= v2;
+    },
+    gte: function (v1, v2) {
+        return v1 >= v2;
+    },
+    and: function () {
+        return Array.prototype.slice.call(arguments).every(Boolean);
+    },
+    or: function () {
+        return Array.prototype.slice.call(arguments, 0, -1).some(Boolean);
+    }
+});
 
 export type Template<Context> = (context: Context) => string;
 

--- a/src/handlebars.ts
+++ b/src/handlebars.ts
@@ -22,7 +22,7 @@ H.registerHelper({
         return v1 >= v2;
     },
     and: function () {
-        return Array.prototype.slice.call(arguments).every(Boolean);
+        return [...arguments].every(Boolean);
     },
     or: function () {
         return Array.prototype.slice.call(arguments, 0, -1).some(Boolean);


### PR DESCRIPTION
This is a feature-request for allowing users to apply more advanced configuration via the input template (HBS) file.

Personal motivation:
I would like to include only `public` and `external` functions in the output documentation.
While the `solidity-docgen` package excludes `private` functions from the output, it still includes `internal` functions.

At present, only a handful of basic operators are supported by the HandleBars language syntax (`if`, `else`, `unless` and a few more - see https://handlebarsjs.com/builtin_helpers.html).

Thus, neither string comparison nor conditional statements are supported (while both are required in order to compare the function `visibility` string to `"public"` and `"external"`).

This short extension will allow the above, via (for example):
```
# Functions:
{{#ownFunctions}}
{{#if (or (eq visibility "public") (eq visibility "external"))}}
- [`{{name}}({{args}})`]
{{/if}}
{{/ownFunctions}}
```
Thanks