### PR TITLE
Allow more advanced programming via the template file

### DIFF
--- a/src/handlebars.ts
+++ b/src/handlebars.ts
@@ -22,10 +22,10 @@ H.registerHelper({
         return v1 >= v2;
     },
     and: function () {
-        return [...arguments].every(Boolean);
+        return Array.prototype.slice.call(arguments).every(Boolean);
     },
     or: function () {
-        return [...arguments].some(Boolean);
+        return Array.prototype.slice.call(arguments, 0, -1).some(Boolean);
     }
 });
 

--- a/src/handlebars.ts
+++ b/src/handlebars.ts
@@ -22,10 +22,10 @@ H.registerHelper({
         return v1 >= v2;
     },
     and: function () {
-        return Array.prototype.slice.call(arguments).every(Boolean);
+        return [...arguments].slice(0, -1).every(Boolean);
     },
     or: function () {
-        return Array.prototype.slice.call(arguments, 0, -1).some(Boolean);
+        return [...arguments].slice(0, -1).some(Boolean);
     }
 });
 


### PR DESCRIPTION
Unfortunately, your changes on PR #46 prevent the `or` function (and possibly also the `and` function) from working correctly:
- [1st change](https://github.com/OpenZeppelin/solidity-docgen/pull/46/commits/2637547c2c6c49f37c4f4fdc95a471b44067e728)
- [2nd change](https://github.com/OpenZeppelin/solidity-docgen/pull/46/commits/d494dd357600efcea0b9ef13de50863f32b0d896)

I have therefore restored (in this PR) the original version (my initial commit from PR #46).

I will admit that I do not entirely understand the logic behind removing the last argument in the `or` function.

However, it clearly seems to be the difference between a successful and an unsuccessful operation of the following HBS statement:
```
{{#ownFunctions}}
{{#if (or (eq visibility "public") (eq visibility "external"))}}
- `{{name}}({{args}})`
{{/if}}
{{/ownFunctions}}
```
In my original commit (as well as here), I have used the suggestion given in [this highly-rated StackOverflow answer](https://stackoverflow.com/a/31632215).
I believe that this piece of code has been pretty thoroughly tested, so I chose to use it exactly as is.
I don't mind changing it of course, given that you know how to do it without impacting the functionality.

Thanks

Update:
---
OK, I've figured this out (on the plane from Milan, hence the delay).
The last argument is a (non-empty) `options` object, which when evaluated as a Boolean, will always evaluate to `true`.
As such, it is meaningless in the case of `every` (in the `and` function), but harmful in the case of `some` (in the `or` function).
That is why it must be omitted in the `or` function.
For consistency (and also for good practice, since it is technically the right thing to do), I have also omitted it in the `and` function.

This time I left no room for assumptions and verified this (patch-3) against my local repo.