### PR TITLE
Add backward-compatibility options for handlebars

### DIFF
--- a/src/handlebars.ts
+++ b/src/handlebars.ts
@@ -32,7 +32,11 @@ H.registerHelper({
 export type Template<Context> = (context: Context) => string;
 
 export function compile(template: string): Template<unknown> {
-  return H.compile(template, { noEscape: true });
+  const compiledTemplate = H.compile(template, { noEscape: true });
+  return context => compiledTemplate(context, {
+      allowProtoPropertiesByDefault: true,
+      allowProtoMethodsByDefault: true
+  });
 }
 
 export function slug(str: string): string {

--- a/src/handlebars.ts
+++ b/src/handlebars.ts
@@ -35,7 +35,7 @@ export function compile(template: string): Template<unknown> {
   const compiledTemplate = H.compile(template, { noEscape: true });
   return context => compiledTemplate(context, {
       allowProtoPropertiesByDefault: true,
-      allowProtoMethodsByDefault: true
+      allowProtoMethodsByDefault: true,
   });
 }
 


### PR DESCRIPTION
This change makes Handlebars >=4.6.0 work like 4.5.3 again, so the generated docs should be OK again