### PR TITLE
Fixing Solc 0.7 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "micromatch": "^4.0.2",
     "minimatch": "^3.0.4",
     "semver": "^7.3.2",
-    "solc": "^0.6.7"
+    "solc": "^0.7.0"
   },
   "devDependencies": {
     "@types/json5": "0.0.30",

--- a/src/solc.ts
+++ b/src/solc.ts
@@ -132,7 +132,7 @@ export class SolcAdapter {
   compile(input: object): SolcOutput {
     const inputJSON = JSON.stringify(input);
 
-    const solcOutputString = semver.satisfies(this.solc.version(), '>0.6')
+    const solcOutputString = semver.satisfies(this.solc.version(), '>=0.6')
       ? this.solc.compile(inputJSON, { import: importCallback })
       : this.solc.compileStandardWrapper(inputJSON, importCallback);
 
@@ -158,7 +158,7 @@ export class SolcAdapter {
       };
     }
 
-    if (semver.satisfies(this.solc.version(), '>0.6')) {
+    if (semver.satisfies(this.solc.version(), '>=0.6')) {
       const adaptDocumentation = (node: any) => {
         if (node.documentation?.text) {
           node.documentation = node.documentation.text;

--- a/src/solc.ts
+++ b/src/solc.ts
@@ -132,7 +132,7 @@ export class SolcAdapter {
   compile(input: object): SolcOutput {
     const inputJSON = JSON.stringify(input);
 
-    const solcOutputString = semver.satisfies(this.solc.version(), '^0.6')
+    const solcOutputString = semver.satisfies(this.solc.version(), '>0.6')
       ? this.solc.compile(inputJSON, { import: importCallback })
       : this.solc.compileStandardWrapper(inputJSON, importCallback);
 
@@ -158,7 +158,7 @@ export class SolcAdapter {
       };
     }
 
-    if (semver.satisfies(this.solc.version(), '^0.6')) {
+    if (semver.satisfies(this.solc.version(), '>0.6')) {
       const adaptDocumentation = (node: any) => {
         if (node.documentation?.text) {
           node.documentation = node.documentation.text;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1513,6 +1513,11 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+follow-redirects@^1.12.1:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
+  integrity sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -3508,13 +3513,14 @@ snapdragon@^0.8.1:
     semver "^5.5.0"
     tmp "0.0.33"
 
-solc@^0.6.7:
-  version "0.6.12"
-  resolved "https://registry.yarnpkg.com/solc/-/solc-0.6.12.tgz#48ac854e0c729361b22a7483645077f58cba080e"
-  integrity sha512-Lm0Ql2G9Qc7yPP2Ba+WNmzw2jwsrd3u4PobHYlSOxaut3TtUbj9+5ZrT6f4DUpNPEoBaFUOEg9Op9C0mk7ge9g==
+solc@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.7.0.tgz#f242ba1888a0b7fe3070a82cd9fd09fcea3e15ad"
+  integrity sha512-4mpz0XimxHpR7X/YIpM2C4hX+wGTenACJX8Vch6I1jgwwQoZElqnaKHD/f2z9/B8jdU5eim5NGcgg3XEY5rcrA==
   dependencies:
     command-exists "^1.2.8"
     commander "3.0.2"
+    follow-redirects "^1.12.1"
     fs-extra "^0.30.0"
     js-sha3 "0.8.0"
     memorystream "^0.3.1"


### PR DESCRIPTION
In order to support 0.7 and newer compilers, we must match ">0.6" instead of "^0.6".