### PR TITLE
Fix pages generated in contracts output mode for multi-contract files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.5.5
+
+- Fixed a bug in the `contracts` output structure that would result in
+  contracts missing from the output if there was more than one defined in the
+  same Solidity source file.
+
+This is technically a breaking change in how output paths are generated, but it
+should not affect most people. In particular, users who follow the convention
+of naming Solidity files by the contract that they contain will not be affected
+at all. Users who follow a different convention and who use the `contracts`
+output structure (the default) will see output files generated in a
+different path.
+
 ## 0.5.4
 
 - Added a `--helpers` (`-H`) option: a path to a file whose exports will be

--- a/src/page.ts
+++ b/src/page.ts
@@ -94,8 +94,8 @@ export class ContractPage extends Page {
   }
 
   get path(): string {
-    const { dir, name } = path.parse(this.contract.file.path);
-    return path.format({ dir, name, ext: '.' + this.ext });
+    const dir = path.dirname(this.contract.file.path);
+    return path.format({ dir, name: this.contract.name, ext: '.' + this.ext });
   }
 }
 

--- a/src/sitemap.test.ts
+++ b/src/sitemap.test.ts
@@ -49,6 +49,21 @@ test('single readme multiple contracts', t => {
   t.assert(page.contracts.some(c => c.name === 'Bar'));
 });
 
+test('single source with file multiple contracts', t => {
+  const source = buildSoliditySource(b => b
+    .file('test.sol')
+      .contract('Foo')
+      .contract('Bar')
+  );
+
+  const sitemap = Sitemap.generate(source, dummyFilter, [], 'md', 'contracts');
+  const { pages } = sitemap;
+
+  t.is(pages.length, 2);
+  t.assert(pages.some(p => p.path === './Foo.md'));
+  t.assert(pages.some(p => p.path === './Bar.md'));
+});
+
 test('filter subdirectory', t => {
   const source = buildSoliditySource(b => b
     .file('Foo.sol')


### PR DESCRIPTION
Fixes #227 

This is technically a breaking change because it changes how output paths are generated, but it should not affect most people. In particular, users who follow the convention of naming Solidity files by the contract that they contain will not be affected at all. Users who follow a different convention will be affected.

Users who want to have multiple contracts in the same source file and use the `contracts` output structure will benefit from this bugfix.