### PR TITLE
Enable using with solc 0.7 compiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "openzeppelin-docs-utils": "github:OpenZeppelin/docs-utils",
     "solc-0-4": "npm:solc@^0.4.24",
     "solc-0-5": "npm:solc@^0.5.14",
+    "solc-0-7": "npm:solc@^0.7.0",
     "typescript": "^4.0.0"
   },
   "keywords": [

--- a/src/solc.test.ts
+++ b/src/solc.test.ts
@@ -26,6 +26,10 @@ async function smokeTest<T>(t: ExecutionContext<T>, solcModule: string, version:
   t.is(undefined, output.errors);
 }
 
+test('smoke test 0.7', async t => {
+  await smokeTest(t, 'solc-0-7', '0.7');
+});
+
 test('smoke test 0.6', async t => {
   await smokeTest(t, 'solc', '0.6');
 });

--- a/src/solc.ts
+++ b/src/solc.ts
@@ -132,7 +132,7 @@ export class SolcAdapter {
   compile(input: object): SolcOutput {
     const inputJSON = JSON.stringify(input);
 
-    const solcOutputString = semver.satisfies(this.solc.version(), '^0.6')
+    const solcOutputString = semver.satisfies(this.solc.version(), '>=0.6')
       ? this.solc.compile(inputJSON, { import: importCallback })
       : this.solc.compileStandardWrapper(inputJSON, importCallback);
 
@@ -158,7 +158,7 @@ export class SolcAdapter {
       };
     }
 
-    if (semver.satisfies(this.solc.version(), '^0.6')) {
+    if (semver.satisfies(this.solc.version(), '>=0.6')) {
       const adaptDocumentation = (node: any) => {
         if (node.documentation?.text) {
           node.documentation = node.documentation.text;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1513,6 +1513,11 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+follow-redirects@^1.12.1:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
+  integrity sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -3501,6 +3506,21 @@ snapdragon@^0.8.1:
   dependencies:
     command-exists "^1.2.8"
     commander "3.0.2"
+    fs-extra "^0.30.0"
+    js-sha3 "0.8.0"
+    memorystream "^0.3.1"
+    require-from-string "^2.0.0"
+    semver "^5.5.0"
+    tmp "0.0.33"
+
+"solc-0-7@npm:solc@^0.7.0":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.7.1.tgz#a8283af3406ada8919a35026ba7469c068c3f839"
+  integrity sha512-LepFVKDOcZ1O3OskOy45XTQ6G4rMRTmsGjn4gssaOrI9uyJI9LL6/X2MlYqeJx22UrpPUtCjQAb5IFWRoOSe+w==
+  dependencies:
+    command-exists "^1.2.8"
+    commander "3.0.2"
+    follow-redirects "^1.12.1"
     fs-extra "^0.30.0"
     js-sha3 "0.8.0"
     memorystream "^0.3.1"


### PR DESCRIPTION
This fixes a problem that was causing `solidity-docgen` not to work with solc 0.7, identified by @villesundell in https://github.com/OpenZeppelin/solidity-docgen/pull/228.

The built in compiler remains solc 0.6, but users who want to use the newer compiler version can do so by installing the desired solc version and using the flag `--solc-module`. Here's an example using npm aliases:

```
npm install -D solc-0.7@npm:solc@^0.7.0
npx solidity-docgen --solc-module solc-0.7
```

Closes #220. Closes #228.