### PR TITLE
Resolve `TypeError: Cannot read property 'replace' of undefined`

### DIFF
--- a/src/source.ts
+++ b/src/source.ts
@@ -173,7 +173,7 @@ export class SourceContract implements Linkable {
   }
 
   get natspec(): NatSpec {
-    if (this.astNode.documentation === null || typeof this.astNode.documentation == 'undefined') {
+    if (this.astNode.documentation === null || this.astNode.documentation === undefined) {
       return {};
     }
 
@@ -216,7 +216,7 @@ abstract class SourceContractItem implements Linkable {
   }
 
   get natspec(): NatSpec {
-    if (this.astNode.documentation === null || typeof this.astNode.documentation == 'undefined') {
+    if (this.astNode.documentation === null || this.astNode.documentation === undefined) {
       return {};
     }
 

--- a/src/source.ts
+++ b/src/source.ts
@@ -173,7 +173,7 @@ export class SourceContract implements Linkable {
   }
 
   get natspec(): NatSpec {
-    if (this.astNode.documentation === null) {
+    if (this.astNode.documentation === null || typeof this.astNode.documentation == 'undefined') {
       return {};
     }
 
@@ -216,7 +216,7 @@ abstract class SourceContractItem implements Linkable {
   }
 
   get natspec(): NatSpec {
-    if (this.astNode.documentation === null) {
+    if (this.astNode.documentation === null || typeof this.astNode.documentation == 'undefined') {
       return {};
     }
 


### PR DESCRIPTION
Resolve for me the following error:
```
$ solidity-docgen --solc-module solc-0.7
TypeError: Cannot read property 'replace' of undefined
```