### PR TITLE
Add strip handlebar helper

### DIFF
--- a/src/handlebars.ts
+++ b/src/handlebars.ts
@@ -1,7 +1,19 @@
+// @ts-nocheck
+// This is needed because ts doesn't allow the use of this within a function block.
+// Maybe there is a better way to solve this. I am not aware of it.
+
 import handlebars, { HelperDeclareSpec } from 'handlebars';
 
 const H = handlebars.create();
 H.registerHelper('slug', slug);
+
+H.registerHelper('strip', function(options){
+    let str = options.fn(this);
+    str = str.trim();
+    str = str.replace("\n", "");
+    return new handlebars.SafeString(str);
+});
+
 H.registerHelper({
     eq: function (v1, v2) {
         return v1 === v2;


### PR DESCRIPTION
Added a handlebar helper. 

Had often the issue when generating a doc that some natspec strings come with a lot of spaces or linebreaks. This messed up my table generation. The solution is not ideal, I had to disable errors from ts. But otherwise, it wouldn't allow me to use _this_ in a _function_ context.
