### PR TITLE
feat: add "contracts" default option for "pages"

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -23,13 +23,13 @@ export interface UserConfig {
 
   /**
    * The way documentable items (contracts, functions, etc.) will be organized
-   * in pages. Built in options are: 'single' for all items in one page, and
-   * 'items' for one page per item. More customization is possible by defining
-   * a function that returns a page path given the AST node for the item and
-   * the source unit where it is defined.
+   * in pages. Built in options are: 'single' for all items in one page, 'items'
+   * for one page per item, and `contracts` for one page per contract. More
+   * customization is possible by defining a function that returns a page path
+   * given the AST node for the item and the source unit where it is defined.
    * Defaults to 'single'.
    */
-  pages?: 'single' | 'items' | ((item: DocItem, file: SourceUnit) => string | undefined);
+  pages?: 'single' | 'items' | 'contracts' | ((item: DocItem, file: SourceUnit) => string | undefined);
 
   /**
    * Clean up the output by collapsing 3 or more contiguous newlines into only 2.

--- a/src/site.ts
+++ b/src/site.ts
@@ -1,3 +1,5 @@
+import { config } from "hardhat";
+import { relative } from 'path';
 import { ContractDefinition, SourceUnit } from 'solidity-ast';
 import { SolcOutput, SolcInput } from 'solidity-ast/solc';
 import { astDereferencer, ASTDereferencer, findAll } from 'solidity-ast/utils';
@@ -21,6 +23,9 @@ export type PageAssigner = Exclude<PageStructure, string>;
 const pageAssigner: Record<PageStructure & string, PageAssigner> = {
   single: () => 'index.md',
   items: (item) => item.name,
+  contracts: (_item, file) => file.absolutePath.startsWith('contracts')
+  ? relative(config.paths.sources, file.absolutePath).replace('.sol', '.md')
+  : undefined,
 };
 
 export interface Site {


### PR DESCRIPTION
My guess is that a page organization mode where a Markdown file is generated for each contract will be needed by many users - so I added a default option for it.