### PR TITLE
Fix mapping

### DIFF
--- a/src/themes/markdown/struct.hbs
+++ b/src/themes/markdown/struct.hbs
@@ -3,7 +3,7 @@
 ```solidity
 struct {{name}} {
 {{#each members}}
-  {{typeName.typeDescriptions.typeString}} {{name}};
+  {{{typeName.typeDescriptions.typeString}}} {{name}};
 {{/each}}
 }
 ```


### PR DESCRIPTION
Similar to: bef7a32802945c0a66eabea6d33e223d2f3f6463 and #376

before:
```solidity
struct Foo {
  mapping(uint256 &#x3D;&gt; string) foo;
}
```
after:
```solidity
struct Foo {
  mapping(uint256 => string) foo;
}
```