### PR TITLE
Add `relativePath` property which is displayed for Contracts

### DIFF
--- a/src/common/properties.ts
+++ b/src/common/properties.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import { EnumDefinition, ErrorDefinition, EventDefinition, FunctionDefinition, ModifierDefinition, ParameterList, StructDefinition, UserDefinedValueTypeDefinition, VariableDeclaration } from 'solidity-ast';
 import { findAll, isNodeType } from 'solidity-ast/utils';
 import { NatSpec, parseNatspec } from '../utils/natspec';
@@ -32,6 +33,10 @@ export function fullName({ item, contract }: DocItemContext): string {
   } else {
     return `${item.name}`;
   }
+}
+
+export function relativePath( { file, siteConfig } : DocItemContext): string {
+  return path.relative(siteConfig.sourcesDir, file.absolutePath);
 }
 
 export function signature({ item }: DocItemContext): string | undefined {

--- a/src/site.ts
+++ b/src/site.ts
@@ -49,6 +49,7 @@ export interface DocItemContext {
   contract?: ContractDefinition;
   file: SourceUnit;
   build: BuildContext;
+  siteConfig: SiteConfig;
 }
 
 export function buildSite(builds: Build[], siteConfig: SiteConfig, properties: Properties = {}): Site {
@@ -74,7 +75,7 @@ export function buildSite(builds: Build[], siteConfig: SiteConfig, properties: P
 
         const page = assignIfIncludedSource(assign, topLevelItem, file, siteConfig);
 
-        const withContext = defineContext(topLevelItem, build, file, page);
+        const withContext = defineContext(topLevelItem, build, file, siteConfig, page);
         defineProperties(withContext, properties);
 
         if (isNewFile && page !== undefined) {
@@ -90,7 +91,7 @@ export function buildSite(builds: Build[], siteConfig: SiteConfig, properties: P
           if (!isDocItem(item)) continue;
           if (isNewFile && page !== undefined) items.push(item as DocItemWithContext);
           const contract = topLevelItem.nodeType === 'ContractDefinition' ? topLevelItem : undefined;
-          const withContext = defineContext(item, build, file, page, contract);
+          const withContext = defineContext(item, build, file, siteConfig, page, contract);
           defineProperties(withContext, properties);
         }
       }
@@ -103,9 +104,9 @@ export function buildSite(builds: Build[], siteConfig: SiteConfig, properties: P
   };
 }
 
-function defineContext(item: DocItem, build: BuildContext, file: SourceUnit, page?: string, contract?: ContractDefinition): DocItemWithContext {
+function defineContext(item: DocItem, build: BuildContext, file: SourceUnit, siteConfig: SiteConfig, page?: string, contract?: ContractDefinition): DocItemWithContext {
   return Object.assign(item, {
-    [DOC_ITEM_CONTEXT]: { build, file, contract, page, item: item as DocItemWithContext },
+    [DOC_ITEM_CONTEXT]: { build, file, siteConfig, contract, page, item: item as DocItemWithContext },
   });
 }
 

--- a/src/themes/markdown/contract.hbs
+++ b/src/themes/markdown/contract.hbs
@@ -1,5 +1,7 @@
 {{>common}}
 
+File: `{{relativePath}}`
+
 {{#each items}}
 {{#hsection}}
 {{>item}}


### PR DESCRIPTION
One downside to the `single` page layout is that the objects' file paths are lost. This change displays the relative file paths for each contract object